### PR TITLE
fix: add OpenCode, fix PATH for AI CLIs

### DIFF
--- a/24.04/Dockerfile
+++ b/24.04/Dockerfile
@@ -64,8 +64,12 @@ USER kasm-user
 
 # Install AI tools (Claude Code, Gemini CLI, OpenAI Codex)
 RUN npm config set prefix /home/kasm-user/.npm-global && \
-    export PATH=/home/kasm-user/.npm-global/bin:$PATH && \
-    npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex
-ENV PATH="/home/kasm-user/.npm-global/bin:${PATH}"
+    npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
+    npm cache clean --force
+
+# Install OpenCode (https://opencode.ai/)
+RUN curl -fsSL https://opencode.ai/install | bash
+
+ENV PATH="/home/kasm-user/.npm-global/bin:/home/kasm-user/.opencode/bin:${PATH}"
 
 ENTRYPOINT [ "/dockerstartup/vnc_startup.sh" ]


### PR DESCRIPTION
## Problem
- OpenCode was missing from this container
- ENV PATH did not include OpenCode's install directory

## Changes
- Add OpenCode install via `curl -fsSL https://opencode.ai/install | bash`
- Add `/home/kasm-user/.opencode/bin` to ENV PATH

## Tools available after this fix
- ✅ `claude` — Claude Code
- ✅ `gemini` — Gemini CLI  
- ✅ `codex` — OpenAI Codex
- ✅ `opencode` — Open Code

Users provide their own API keys / login to their accounts.